### PR TITLE
pg_bigmが利用できるよう、ノートの検索をILIKE演算子でなくLIKE演算子でLOWER()をかけたテキストに対して行うように

### DIFF
--- a/packages/backend/src/core/SearchService.ts
+++ b/packages/backend/src/core/SearchService.ts
@@ -161,7 +161,7 @@ export class SearchService {
 			}
 
 			query
-				.andWhere('note.text ILIKE :q', { q: `%${ sqlLikeEscape(q) }%` })
+				.andWhere('LOWER(note.text) LIKE :q', { q: `%${ sqlLikeEscape(q.toLowerCase()) }%` })
 				.innerJoinAndSelect('note.user', 'user')
 				.leftJoinAndSelect('note.reply', 'reply')
 				.leftJoinAndSelect('note.renote', 'renote')


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What

ノート検索はnote.textに対してILIKE演算子で %検索ワード% をマッチさせており、これで大小文字を同一視した検索をしています。  
これを、LOWER(note.text)に対してLIKE演算子で %小文字化した検索ワード% を使うように変更し、動作は変えずにILIKE演算子を不使用にしています。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

- 日本語にも対応した高速全文検索拡張のpg_bigmがLIKE演算子のみに対応しており、ILIKE演算子には非対応のためです
- StackOverflowでの問答のみがソースですが、インデックスのない状態ではLOWER-LIKEのほうがILIKEよりもパフォーマンス上もやや分がありそうです https://stackoverflow.com/questions/20336665/lower-like-vs-ilike